### PR TITLE
Better Container Killing - Use `dumb-init` to Add Signal Propagation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,5 +7,5 @@ COPY sites-available /etc/apache2/sites-available
 
 RUN rm -rf /var/www/html
 
-ENTRYPOINT ["/usr/bin/dumb-init", "--rewrite", "15:28", "--"]
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
 CMD ["/usr/sbin/apachectl", "-D FOREGROUND"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,11 @@
 FROM debian:buster-slim
 
-RUN apt-get update && apt-get install -y apache2 && apt-get clean
+RUN apt-get update && apt-get install -y apache2 dumb-init && apt-get clean
 
 COPY apache2.conf /etc/apache2/
 COPY sites-available /etc/apache2/sites-available
 
 RUN rm -rf /var/www/html
 
-CMD /usr/sbin/apachectl -DFOREGROUND
+ENTRYPOINT ["/usr/bin/dumb-init", "--rewrite", "15:28", "--"]
+CMD ["/usr/sbin/apachectl", "-D FOREGROUND"]


### PR DESCRIPTION
- `docker-compose` will terminate if `apachectl` fails
- `docker` will terminate if `apachectl` fails
